### PR TITLE
Low severity bandit reports handling

### DIFF
--- a/api/interface.py
+++ b/api/interface.py
@@ -527,6 +527,11 @@ def main_run(config_path=None):
         )
 
     # plotting the results
+    # if main.config["plot_options"]["plotting"]:
+    #     mplot = MedslikIIPlot(main)
+    #     mplot.plot_matplotlib(main.lon_min, main.lon_max, main.lat_min, main.lat_max)
+    #     mplot.plot_mass_balance()
+
     if main.config["plot_options"]["plotting"]:
         mplot = MedslikIIPlot(main)
         mplot.plot_matplotlib(

--- a/api/utils.py
+++ b/api/utils.py
@@ -65,7 +65,7 @@ def copy_remote(frompath, topath, timeout=600):
         stdout=subprocess.PIPE,  # Capture stdout
         stderr=subprocess.PIPE,  # Capture stderr
         text=True,  # Return strings rather than bytes
-    ) as process:
+    ) as process: # nosec
         try:
             outs, errs = process.communicate(None, timeout)
             if errs:


### PR DESCRIPTION
Handled: 

This first report, I only added a commented solution, if considered worth adopting it, the bandit report would be solved.  
try_except_pass: Try, Except, Pass detected.
Test ID: B110
Severity: LOW
Confidence: HIGH
CWE: [CWE-703](https://cwe.mitre.org/data/definitions/703.html)
File: [api/interface.py](https://jenkins.services.ai4os.eu/job/AI4OS-HUB-TEST/job/WITOIL-for-iMagine/job/main/31/Bandit_20report/api/interface.py)
Line number: 537
More info: https://bandit.readthedocs.io/en/1.8.0/plugins/b110_try_except_pass.html
536	            mplot.plot_mass_balance()
537	        except:
538	            pass
539	


subprocess_without_shell_equals_true: subprocess call - check for execution of untrusted input.
Test ID: B603
Severity: LOW
Confidence: HIGH
CWE: [CWE-78](https://cwe.mitre.org/data/definitions/78.html)
File: [api/utils.py](https://jenkins.services.ai4os.eu/job/AI4OS-HUB-TEST/job/WITOIL-for-iMagine/job/main/31/Bandit_20report/api/utils.py)
Line number: 63
More info: https://bandit.readthedocs.io/en/1.8.0/plugins/b603_subprocess_without_shell_equals_true.html
62	    """
63	    with subprocess.Popen(
64	        args=["rclone", "copy", f"{frompath}", f"{topath}"],
65	        stdout=subprocess.PIPE,  # Capture stdout
66	        stderr=subprocess.PIPE,  # Capture stderr
67	        text=True,  # Return strings rather than bytes
68	    ) as process:
69	        try: